### PR TITLE
FEAT: simple python script for easier customization of the package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,22 @@ Option 2: Build Your Own
 ------------------------
 
 To create your own package, place the Xcode Installer for your OS version
-(``Install Xcode.app``) in the root directory of the repository, then open
-the matching ``.pmdoc`` to build!
+(``Install Xcode.app``) in the root directory of the repository, and edit the
+packages_list.txt file to include the packages you want. Then run the build.py script::
+
+        python build.py
+
+it will produce a build_essentials.pkg file by default, containing all the
+desired packages. For example, if you want to include all the default packages
+but want to add the 10.6 SDK, the file would look as follows::
+
+        DevSDK.pkg
+        DeveloperToolsCLI.pkg
+        MacOSX10.6.pkg
+        clang.pkg
+        llvm-gcc4.2.pkg
+        gcc4.2.pkg
+
 
 What's Included?
 ----------------

--- a/build.py
+++ b/build.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+import optparse
+import subprocess
+import sys
+import tempfile
+
+import os.path as op
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    usage = "usage: %prog [options] packages_path packages_list.txt"
+
+    parser = optparse.OptionParser(usage)
+    parser.add_option("-o", dest="output_file",
+                      help="Output package name (default: %(default)s",
+                      default="build_essentials.pkg")
+    parser.add_option("--packages-list", dest="packages_list",
+                      help="File containing the list of packages to include (default %(default)s)",
+                      default="packages_list.txt")
+    parser.add_option("--packages-path", dest="packages_path",
+                      help="Directory which contains the packages (default %(default)s)",
+                      default="Install Xcode.app/Contents/Resources/Packages")
+
+    (options, args) = parser.parse_args()
+    if len(args) != 0:
+        parser.print_help()
+        sys.exit(0)
+    
+    packages_path = options.packages_path
+    packages_list = options.packages_list
+
+    with tempfile.NamedTemporaryFile(suffix=".xml") as fp:
+        dist_file = fp.name
+        cmd = ["productbuild", "--synthesize"]
+        with open(packages_list, "rt") as fp:
+            for entry in fp:
+                cmd.extend(["--package", op.join(packages_path, entry.rstrip())])
+            cmd += [dist_file]
+        subprocess.check_call(cmd)
+
+        cmd = ["productbuild", "--distribution", dist_file,
+               "--package-path", packages_path, options.output_file]
+        subprocess.check_call(cmd)
+ 
+if __name__ == "__main__":
+    main()

--- a/packages_list.txt
+++ b/packages_list.txt
@@ -1,0 +1,10 @@
+CoreAudioSDK.pkg
+DevSDK.pkg
+DeveloperToolsCLI.pkg
+MacOSX10.6.pkg
+OpenGLSDK.pkg
+QuickTimeSDK.pkg
+WebKitSDK.pkg
+clang.pkg
+llvm-gcc4.2.pkg
+gcc4.2.pkg


### PR DESCRIPTION
I tried to customize the installer to our need to include the OS X 10.6 SDK, but editing .pmdoc files is not my idea of fun, so I created a small python script to customize the installer from a simple text file instead. The readme explains how to do it.

We are using it @enthought to provision our OS X build vm, and it has worked well for us (on 10.7 VMs).